### PR TITLE
fix(validators): handle both feature_list.json schemas (#22)

### DIFF
--- a/tests/test_e2e_hook_schema.py
+++ b/tests/test_e2e_hook_schema.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Test E2E Hook Schema Handling
+
+Tests that the e2e_hook correctly handles both JSON formats.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from validators.e2e_hook import get_current_feature
+
+
+class TestE2EHookSchema:
+    """Test that e2e_hook handles different feature_list.json schemas."""
+
+    @pytest.fixture
+    def temp_project(self, tmp_path):
+        """Create a temporary project directory."""
+        project_dir = tmp_path / "test_project"
+        project_dir.mkdir()
+        spec_dir = project_dir / "spec"
+        spec_dir.mkdir()
+        return project_dir
+
+    def test_flat_array_format(self, temp_project):
+        """Test handling of flat array format [...] (Anthropic standard)."""
+        features = [
+            {"id": "1", "description": "Feature 1", "passes": True},
+            {"id": "2", "description": "Feature 2", "passes": False},
+            {"id": "3", "description": "Feature 3", "passes": False},
+        ]
+        
+        feature_list_path = temp_project / "spec" / "feature_list.json"
+        with open(feature_list_path, "w") as f:
+            json.dump(features, f)
+        
+        current = get_current_feature(temp_project)
+        
+        assert current is not None
+        assert current["id"] == "2"  # First non-passing feature
+
+    def test_wrapped_format(self, temp_project):
+        """Test handling of wrapped format {"features": [...]} (legacy)."""
+        data = {
+            "features": [
+                {"id": "1", "description": "Feature 1", "passing": True},
+                {"id": "2", "description": "Feature 2", "passing": False},
+            ]
+        }
+        
+        feature_list_path = temp_project / "spec" / "feature_list.json"
+        with open(feature_list_path, "w") as f:
+            json.dump(data, f)
+        
+        current = get_current_feature(temp_project)
+        
+        assert current is not None
+        assert current["id"] == "2"
+
+    def test_passes_key(self, temp_project):
+        """Test handling of 'passes' key (Anthropic standard)."""
+        features = [
+            {"id": "1", "passes": True},
+            {"id": "2", "passes": False},
+        ]
+        
+        feature_list_path = temp_project / "spec" / "feature_list.json"
+        with open(feature_list_path, "w") as f:
+            json.dump(features, f)
+        
+        current = get_current_feature(temp_project)
+        
+        assert current is not None
+        assert current["id"] == "2"
+
+    def test_passing_key(self, temp_project):
+        """Test handling of 'passing' key (legacy)."""
+        features = [
+            {"id": "1", "passing": True},
+            {"id": "2", "passing": False},
+        ]
+        
+        feature_list_path = temp_project / "spec" / "feature_list.json"
+        with open(feature_list_path, "w") as f:
+            json.dump(features, f)
+        
+        current = get_current_feature(temp_project)
+        
+        assert current is not None
+        assert current["id"] == "2"
+
+    def test_all_passing_returns_none(self, temp_project):
+        """When all features pass, should return None."""
+        features = [
+            {"id": "1", "passes": True},
+            {"id": "2", "passes": True},
+        ]
+        
+        feature_list_path = temp_project / "spec" / "feature_list.json"
+        with open(feature_list_path, "w") as f:
+            json.dump(features, f)
+        
+        current = get_current_feature(temp_project)
+        
+        assert current is None
+
+    def test_missing_file_returns_none(self, temp_project):
+        """When feature_list.json doesn't exist, should return None."""
+        current = get_current_feature(temp_project)
+        assert current is None
+
+    def test_invalid_json_returns_none(self, temp_project):
+        """When feature_list.json is invalid, should return None."""
+        feature_list_path = temp_project / "spec" / "feature_list.json"
+        with open(feature_list_path, "w") as f:
+            f.write("not valid json {{{")
+        
+        current = get_current_feature(temp_project)
+        assert current is None
+
+    def test_empty_array_returns_none(self, temp_project):
+        """When feature list is empty, should return None."""
+        feature_list_path = temp_project / "spec" / "feature_list.json"
+        with open(feature_list_path, "w") as f:
+            json.dump([], f)
+        
+        current = get_current_feature(temp_project)
+        assert current is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/validators/e2e_hook.py
+++ b/validators/e2e_hook.py
@@ -18,12 +18,17 @@ def get_current_feature(project_dir: Path) -> dict | None:
         try:
             with open(feature_list_path) as f:
                 data = json.load(f)
-                features = data.get("features", [])
+                # Handle both formats: flat array [...] or wrapped {"features": [...]}
+                if isinstance(data, list):
+                    features = data
+                else:
+                    features = data.get("features", [])
                 # Find first feature that's not passing
+                # Support both "passes" (Anthropic standard) and "passing" (legacy) keys
                 for feature in features:
-                    if not feature.get("passing", False):
+                    if not feature.get("passes", feature.get("passing", False)):
                         return feature
-        except:
+        except (OSError, json.JSONDecodeError):
             pass
 
     # Check for .next_feature.json (continuation mode)
@@ -32,7 +37,7 @@ def get_current_feature(project_dir: Path) -> dict | None:
         try:
             with open(next_feature_path) as f:
                 return json.load(f)
-        except:
+        except (OSError, json.JSONDecodeError):
             pass
 
     return None


### PR DESCRIPTION
## Summary
Fixes #22 - The e2e_hook was expecting a wrapped JSON schema but agent.py uses a flat array.

## Changes
- Support flat array `[...]` format (Anthropic standard)
- Support wrapped `{"features": [...]}` format (legacy)
- Support both `passes` and `passing` keys for feature status
- Add proper exception handling for file/JSON errors

## Root Cause
The e2e_hook had:
```python
features = data.get("features", [])  # Expected wrapped format
```

But agent.py reads the file as:
```python
features = json.load(f)  # Flat array
```

This caused the hook to always get an empty list, silently disabling E2E validation.

## Testing
- Syntax validated with py_compile