### PR TITLE
fix(prompts): wire iteration_mode through prompt loading (#13)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -282,12 +282,12 @@ async def run_autonomous_agent(
         # Create client (fresh context) with mode-specific MCP servers
         client = create_client(project_dir, model, mode)
 
-        # Choose prompt based on session type and mode
+        # Choose prompt based on session type, mode, and iteration mode
         if is_first_run:
-            prompt = get_initializer_prompt(mode)
+            prompt = get_initializer_prompt(mode, iteration_mode)
             is_first_run = False  # Only use initializer once
         else:
-            prompt = get_coding_prompt(mode)
+            prompt = get_coding_prompt(mode, iteration_mode)
 
         # Reset loop detector for fresh session
         loop_detector.reset()

--- a/prompts/__init__.py
+++ b/prompts/__init__.py
@@ -8,28 +8,35 @@ Functions for loading prompt templates from the prompts directory.
 import shutil
 from pathlib import Path
 
+from bash_loops import get_e2e_debugging_loop, get_feature_quality_loop
 from setup_mcp import MCPServerSetup
 
 # PROMPTS_DIR is now the package directory itself
 PROMPTS_DIR = Path(__file__).parent
 
 
-def load_prompt(name: str, mode: str = "greenfield") -> str:
+def load_prompt(name: str, mode: str = "greenfield", iteration_mode: str = "ralph") -> str:
     """
     Load a prompt template from the prompts directory.
 
     Args:
         name: Prompt filename (without .md extension)
         mode: Execution mode (for MCP tool injection)
+        iteration_mode: "ralph" (Ralph Wiggum plugin) or "bash" (v3.7.0 bash loops)
 
     Returns:
-        Prompt text with MCP tool documentation injected
+        Prompt text with MCP tool documentation and iteration loops injected
     """
     prompt_path = PROMPTS_DIR / f"{name}.md"
     prompt = prompt_path.read_text()
 
     # Inject MCP tool documentation
-    return inject_mcp_tools(prompt, mode)
+    prompt = inject_mcp_tools(prompt, mode)
+
+    # Inject iteration loop templates for bash mode
+    prompt = inject_iteration_loops(prompt, iteration_mode)
+
+    return prompt
 
 
 def inject_mcp_tools(prompt: str, mode: str) -> str:
@@ -85,24 +92,61 @@ def inject_mcp_tools(prompt: str, mode: str) -> str:
     return prompt
 
 
-def get_initializer_prompt(mode: str = "greenfield") -> str:
+def inject_iteration_loops(prompt: str, iteration_mode: str) -> str:
+    """
+    Inject iteration loop templates based on iteration mode.
+
+    For "bash" mode (v3.7.0 compatibility), injects bash loop scripts.
+    For "ralph" mode, relies on Ralph Wiggum plugin (no injection needed).
+
+    Args:
+        prompt: The prompt template
+        iteration_mode: "ralph" or "bash"
+
+    Returns:
+        Prompt with iteration loops injected (or unchanged for ralph mode)
+    """
+    if iteration_mode != "bash":
+        # Ralph mode - remove any bash loop placeholders, Ralph handles iteration
+        prompt = prompt.replace("{{E2E_DEBUGGING_LOOP}}", "")
+        prompt = prompt.replace("{{FEATURE_QUALITY_LOOP}}", "")
+        return prompt
+
+    # Bash mode - inject the loop templates
+    e2e_loop = get_e2e_debugging_loop(iteration_mode)
+    quality_loop = get_feature_quality_loop(iteration_mode)
+
+    prompt = prompt.replace("{{E2E_DEBUGGING_LOOP}}", e2e_loop)
+    prompt = prompt.replace("{{FEATURE_QUALITY_LOOP}}", quality_loop)
+
+    # Also append loops at the end if placeholders weren't found
+    if "{{E2E_DEBUGGING_LOOP}}" not in prompt and e2e_loop:
+        prompt += f"\n\n## E2E Debugging Loop (Bash Mode)\n{e2e_loop}"
+
+    if "{{FEATURE_QUALITY_LOOP}}" not in prompt and quality_loop:
+        prompt += f"\n\n## Feature Quality Loop (Bash Mode)\n{quality_loop}"
+
+    return prompt
+
+
+def get_initializer_prompt(mode: str = "greenfield", iteration_mode: str = "ralph") -> str:
     """Load the initializer prompt based on mode."""
     if mode == "enhancement":
-        return load_prompt("enhancement_initializer_prompt", mode)
+        return load_prompt("enhancement_initializer_prompt", mode, iteration_mode)
     elif mode == "bugfix":
-        return load_prompt("enhancement_initializer_prompt", mode)  # Same as enhancement
+        return load_prompt("enhancement_initializer_prompt", mode, iteration_mode)  # Same as enhancement
     else:
-        return load_prompt("initializer_prompt", mode)
+        return load_prompt("initializer_prompt", mode, iteration_mode)
 
 
-def get_coding_prompt(mode: str = "greenfield") -> str:
+def get_coding_prompt(mode: str = "greenfield", iteration_mode: str = "ralph") -> str:
     """Load the coding agent prompt based on mode."""
     if mode == "enhancement":
-        return load_prompt("enhancement_coding_prompt", mode)
+        return load_prompt("enhancement_coding_prompt", mode, iteration_mode)
     elif mode == "bugfix":
-        return load_prompt("bugfix_mode_prompt", mode)
+        return load_prompt("bugfix_mode_prompt", mode, iteration_mode)
     else:
-        return load_prompt("coding_prompt", mode)
+        return load_prompt("coding_prompt", mode, iteration_mode)
 
 
 def copy_spec_to_project(

--- a/tests/test_iteration_mode.py
+++ b/tests/test_iteration_mode.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Test Iteration Mode Prompt Injection
+
+Tests that iteration_mode affects prompt loading correctly.
+"""
+
+import pytest
+
+from prompts import get_coding_prompt, get_initializer_prompt, inject_iteration_loops
+
+
+class TestIterationMode:
+    """Test iteration mode affects prompts correctly."""
+
+    def test_inject_iteration_loops_bash_mode(self):
+        """Bash mode should inject loop templates."""
+        prompt = "Test prompt {{E2E_DEBUGGING_LOOP}} more text {{FEATURE_QUALITY_LOOP}} end"
+        
+        result = inject_iteration_loops(prompt, "bash")
+        
+        # Should have replaced placeholders with bash loop content
+        assert "{{E2E_DEBUGGING_LOOP}}" not in result
+        assert "{{FEATURE_QUALITY_LOOP}}" not in result
+        # Bash loops contain these markers
+        assert "E2E Debugging" in result or "#!/bin/bash" in result
+
+    def test_inject_iteration_loops_ralph_mode(self):
+        """Ralph mode should remove placeholders (Ralph handles iteration)."""
+        prompt = "Test prompt {{E2E_DEBUGGING_LOOP}} more text {{FEATURE_QUALITY_LOOP}} end"
+        
+        result = inject_iteration_loops(prompt, "ralph")
+        
+        # Should have removed placeholders
+        assert "{{E2E_DEBUGGING_LOOP}}" not in result
+        assert "{{FEATURE_QUALITY_LOOP}}" not in result
+        # Should NOT have bash loop content
+        assert "#!/bin/bash" not in result
+
+    def test_get_coding_prompt_accepts_iteration_mode(self):
+        """get_coding_prompt should accept iteration_mode parameter."""
+        # Should not raise
+        prompt_ralph = get_coding_prompt(mode="greenfield", iteration_mode="ralph")
+        prompt_bash = get_coding_prompt(mode="greenfield", iteration_mode="bash")
+        
+        assert isinstance(prompt_ralph, str)
+        assert isinstance(prompt_bash, str)
+        assert len(prompt_ralph) > 0
+        assert len(prompt_bash) > 0
+
+    def test_get_initializer_prompt_accepts_iteration_mode(self):
+        """get_initializer_prompt should accept iteration_mode parameter."""
+        # Should not raise
+        prompt_ralph = get_initializer_prompt(mode="greenfield", iteration_mode="ralph")
+        prompt_bash = get_initializer_prompt(mode="greenfield", iteration_mode="bash")
+        
+        assert isinstance(prompt_ralph, str)
+        assert isinstance(prompt_bash, str)
+
+    def test_bash_mode_appends_loops_if_no_placeholders(self):
+        """Bash mode should append loops at end if no placeholders found."""
+        # Simulate a prompt without placeholders
+        prompt = "Simple prompt with no placeholders"
+        
+        result = inject_iteration_loops(prompt, "bash")
+        
+        # Should have appended loop content at the end
+        assert len(result) > len(prompt)
+
+    def test_ralph_mode_unchanged_if_no_placeholders(self):
+        """Ralph mode should return unchanged if no placeholders."""
+        prompt = "Simple prompt with no placeholders"
+        
+        result = inject_iteration_loops(prompt, "ralph")
+        
+        # Should be unchanged
+        assert result == prompt
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Fixes #13 - The `iteration_mode` parameter was accepted but never used, making `--force-ralph` and `--force-bash` flags no-ops.

## Changes
- Add `iteration_mode` parameter to `load_prompt()`, `get_coding_prompt()`, `get_initializer_prompt()`
- Add `inject_iteration_loops()` function to inject bash loop templates
- Pass `iteration_mode` from agent.py to prompt functions
- For 'bash' mode: inject E2E debugging and feature quality loops from bash_loops.py
- For 'ralph' mode: rely on Ralph Wiggum plugin (no injection needed)

## Root Cause
The iteration_mode was detected in autonomous_agent.py and passed to run_autonomous_agent(), but was never forwarded to the prompt loading functions. The bash loop templates in bash_loops.py were never injected into the prompts.

## Testing
- Syntax validated with py_compile